### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,8 @@ var Deffy = require("deffy");
  * @return {Object|Array} The field value.
  */
 function SetOrGet(input, field, def) {
+    if (field == '__proto__' || field == 'constructor' || field == 'prototype')
+        throw new Error('Restricted setting magical attributes')
     return input[field] = Deffy(input[field], def);
 }
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`set-or-get` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-set-or-get

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var SetOrGet = require("set-or-get");
var obj = {}
console.log("Before : " + {}.polluted);
SetOrGet(obj, "__proto__", {}).polluted ='Yes! Its Polluted';
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i set-or-get # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

Because `prototype pollution` is exploitable by assigning a property to the function return value (the prototype object itself), fix by skipping vulnerable condition is not a good option as it will throw `Cannot set property of undefined` error like below. Instead, the fix throws a new exception when trying to assign magical attributes.

![pof](https://raw.githubusercontent.com/arjunshibu/files/main/set-or-get-fix.png)


### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
